### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: lpme
+          extra-packages: any::testthat
+      - name: Install package
+        run: R CMD INSTALL lpme
+      - name: Run tests
+        run: Rscript -e 'library(lpme); testthat::test_dir("tests/testthat")'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # `lpme`:  R Package for Dealing with Latent Predictor Measurement Error Under Identification Restrictions
+[![CI](https://github.com/cjerzak/lpme-software/actions/workflows/ci.yml/badge.svg)](https://github.com/cjerzak/lpme-software/actions/workflows/ci.yml)
 [**Installation**](#installation)
 | [**Key Functions**](#keyfxns)
 | [**References**](#references)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(lpme)
+
+test_check("lpme")

--- a/tests/testthat/test_lpme.R
+++ b/tests/testthat/test_lpme.R
@@ -1,0 +1,35 @@
+test_that("lpme basic functionality", {
+  set.seed(123)
+  Y <- rnorm(80)
+  obs <- as.data.frame(matrix(sample(c(0,1), 80*4, replace=TRUE), ncol=4))
+  res <- lpme(Y, obs, n_boot = 1, n_partition = 1, estimation_method = "pca")
+  expect_s3_class(res, "lpme")
+  expect_true("ols_coef" %in% names(res))
+})
+
+test_that("lpme orientation_signs validation", {
+  set.seed(123)
+  Y <- rnorm(80)
+  obs <- as.data.frame(matrix(sample(c(0,1), 80*4, replace=TRUE), ncol=4))
+  expect_error(
+    lpme(Y, obs, n_boot = 1, n_partition = 1, estimation_method = "pca",
+         orientation_signs = c(1, 0, 1)),
+    "orientation_signs"
+  )
+})
+
+test_that("lpme S3 methods", {
+  set.seed(123)
+  Y <- rnorm(80)
+  obs <- as.data.frame(matrix(sample(c(0,1), 80*4, replace=TRUE), ncol=4))
+  res <- lpme(Y, obs, n_boot = 1, n_partition = 1, estimation_method = "pca")
+  sum_df <- summary(res)
+  expect_s3_class(sum_df, "data.frame")
+  expect_equal(
+    row.names(sum_df),
+    c("OLS", "IV", "Corrected IV", "Corrected OLS", "Bayesian OLS (Outer)", "Bayesian OLS (Inner)")
+  )
+  expect_type(capture.output(print(res)), "character")
+  expect_silent(plot(res))
+  expect_error(plot(res, type = "coefficients"))
+})

--- a/tests/testthat/test_lpme_onerun.R
+++ b/tests/testthat/test_lpme_onerun.R
@@ -1,0 +1,20 @@
+test_that("lpme_onerun basic functionality", {
+  set.seed(123)
+  Y <- rnorm(20)
+  obs <- as.data.frame(matrix(sample(c(0,1), 20*4, replace=TRUE), ncol=4))
+  res <- lpme_onerun(Y, obs, estimation_method = "pca")
+  expect_s3_class(res, "lpme_onerun")
+  expect_true(all(c("ols_coef", "x_est1", "x_est2") %in% names(res)))
+})
+
+test_that("lpme_onerun S3 methods work", {
+  set.seed(123)
+  Y <- rnorm(20)
+  obs <- as.data.frame(matrix(sample(c(0,1), 20*4, replace=TRUE), ncol=4))
+  res <- lpme_onerun(Y, obs, estimation_method = "pca")
+  sum_df <- summary(res)
+  expect_s3_class(sum_df, "data.frame")
+  expect_equal(row.names(sum_df), c("OLS", "IV", "Corrected IV", "Corrected OLS"))
+  expect_type(capture.output(print(res)), "character")
+  expect_silent(plot(res))
+})


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for running tests
- write `testthat` unit tests covering `lpme_onerun`, `lpme`, and S3 methods
- include a CI status badge in the README

## Testing
- `R --vanilla -q -e "library(lpme); testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_683e5e8211b0832fa302705d5575d350