### PR TITLE
Fix typos in documentation

### DIFF
--- a/lpme/R/lpme_BuildBackend.R
+++ b/lpme/R/lpme_BuildBackend.R
@@ -1,4 +1,6 @@
-#' A function to build the environment for lpme. Builds a conda environment in which 'JAX', 'numpyro', and 'np' are installed. Users can also create a conda environment where 'JAX' and 'np' are installed themselves. 
+#' A function to build the environment for lpme. Builds a conda environment in which
+#' 'JAX', 'numpyro', and 'numpy' are installed. Users can also create a conda
+#' environment where 'JAX' and 'numpy' are installed themselves.
 #'
 #' @param conda_env (default = `"lpme"`) Name of the conda environment in which to place the backends.
 #' @param conda (default = `auto`) The path to a conda executable. Using `"auto"` allows reticulate to attempt to automatically find an appropriate conda binary.

--- a/lpme/R/lpme_DoBootPartition.R
+++ b/lpme/R/lpme_DoBootPartition.R
@@ -95,8 +95,8 @@
 #'
 #' @details 
 #' This function implements a bootstrapped latent variable analysis with measurement error correction. 
-#' It performs multiple bootstrap iterations, each with multiple partitions. For each partition, 
-#' it calls the LatentOneRun function to estimate latent variables and apply various correction methods. 
+#' It performs multiple bootstrap iterations, each with multiple partitions. For each partition,
+#' it calls the \code{lpme_onerun} function to estimate latent variables and apply various correction methods.
 #' The results are then aggregated across partitions and bootstrap iterations to produce final estimates 
 #' and bootstrap standard errors.
 #'
@@ -154,7 +154,7 @@ lpme <- function(Y,
       stop("orientation_signs must contain only 1 and -1.")
     }
     if(!all(unlist(observables) %in% c(0,1))){
-      stop("Re-orientation in the non-binary case not yet implementated")
+      stop("Re-orientation in the non-binary case not yet implemented")
     }
     if(all(observables %in% c(0,1))){
       colnames_observables <- colnames(observables)

--- a/lpme/man/build_backend.Rd
+++ b/lpme/man/build_backend.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/lpme_BuildBackend.R
 \name{build_backend}
 \alias{build_backend}
-\title{A function to build the environment for lpme. Builds a conda environment in which 'JAX', 'numpyro', and 'np' are installed. Users can also create a conda environment where 'JAX' and 'np' are installed themselves.}
+\title{A function to build the environment for lpme. Builds a conda environment in which 'JAX', 'numpyro', and 'numpy' are installed. Users can also create a conda environment where 'JAX' and 'numpy' are installed themselves.}
 \usage{
 build_backend(conda_env = "lpme", conda = "auto")
 }
@@ -18,7 +18,7 @@ This function requires an Internet connection.
 You can find out a list of conda Python paths via: \code{Sys.which("python")}
 }
 \description{
-A function to build the environment for lpme. Builds a conda environment in which 'JAX', 'numpyro', and 'np' are installed. Users can also create a conda environment where 'JAX' and 'np' are installed themselves.
+A function to build the environment for lpme. Builds a conda environment in which 'JAX', 'numpyro', and 'numpy' are installed. Users can also create a conda environment where 'JAX' and 'numpy' are installed themselves.
 }
 \examples{
 \dontrun{

--- a/lpme/man/lpme.Rd
+++ b/lpme/man/lpme.Rd
@@ -134,8 +134,8 @@ Implements bootstrapped analysis for latent variable models with measurement err
 }
 \details{
 This function implements a bootstrapped latent variable analysis with measurement error correction. 
-It performs multiple bootstrap iterations, each with multiple partitions. For each partition, 
-it calls the LatentOneRun function to estimate latent variables and apply various correction methods. 
+It performs multiple bootstrap iterations, each with multiple partitions. For each partition,
+it calls the \code{lpme_onerun} function to estimate latent variables and apply various correction methods.
 The results are then aggregated across partitions and bootstrap iterations to produce final estimates 
 and bootstrap standard errors.
 }


### PR DESCRIPTION
## Summary
- correct description of backend setup
- fix reference to lpme_onerun in lpme() documentation
- fix typo in boot partition re-orientation error message

## Testing
- `R CMD build lpme` *(fails: there is no package called 'rmarkdown')*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: could not find function "lpme_onerun")*

------
https://chatgpt.com/codex/tasks/task_e_683f59401f80832fbdd0a79a220f2cee