### PR TITLE
Fix typos in tutorial comments

### DIFF
--- a/tutorial/IntroTutorial.R
+++ b/tutorial/IntroTutorial.R
@@ -66,7 +66,7 @@
                 chain_method = "sequential", 
                 n_thin_by = 1L, 
                 n_chains = 2L), 
-      conda_env = "lpme"  # Specify your conda environment, used in this condition, backend="numpryo" 
+      conda_env = "lpme"  # Specify your conda environment, used in this condition, backend="numpyro"
   )
   mcmc_overimputation_results <- lpme(
     Y = Yobs,
@@ -81,7 +81,7 @@
       chain_method = "sequential", 
       n_thin_by = 1L, 
       n_chains = 2L), 
-    conda_env = "lpme"  # Specify your conda environment, used in this condition, backend="numpryo" 
+  conda_env = "lpme"  # Specify your conda environment, used in this condition, backend="numpyro"
   )
   mcmc_joint_results <- lpme(
     Y = Yobs,
@@ -95,7 +95,7 @@
       chain_method = "sequential", 
       n_thin_by = 1L, 
       n_chains = 2L), 
-    conda_env = "lpme"  # Specify your conda environment, used in this condition, backend="numpryo" 
+    conda_env = "lpme"  # Specify your conda environment, used in this condition, backend="numpyro"
   )
 
   # compare 


### PR DESCRIPTION
## Summary
- correct `numpyro` spelling in IntroTutorial

## Testing
- `R -q -e "devtools::load_all('lpme'); testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_685ae8da4668832fa95dae34899ee348