### PR TITLE
Fix infer_orientation_signs NA handling

### DIFF
--- a/lpme/R/lpme_DoBootPartition.R
+++ b/lpme/R/lpme_DoBootPartition.R
@@ -160,10 +160,10 @@ lpme <- function(Y,
     if (!all(orientation_signs %in% c(1, -1))) {
       stop("orientation_signs must contain only 1 and -1.")
     }
-    if(!all(unlist(observables) %in% c(0,1))){
+    if(!all(na.omit(unlist(observables)) %in% c(0,1))){
       stop("Re-orientation in the non-binary case not yet implemented")
     }
-    if(all(observables %in% c(0,1))){
+    if(all(na.omit(unlist(observables)) %in% c(0,1))){
       colnames_observables <- colnames(observables)
       observables <- sapply(1:ncol(observables), function(d_){
         observables[, d_] <- orientation_signs[d_] * observables[, d_] + 

--- a/lpme/R/orientation_helpers.R
+++ b/lpme/R/orientation_helpers.R
@@ -28,7 +28,9 @@
 #' @export
 infer_orientation_signs <- function(Y, observables, method = c("Y", "PC1")) {
   method <- match.arg(method)
-  if (!all(unlist(observables) %in% c(0, 1))) {
+  # allow for missing values when validating the observables
+  obs_vals <- na.omit(unlist(observables))
+  if (!all(obs_vals %in% c(0, 1))) {
     stop("infer_orientation_signs currently supports only binary observables")
   }
   if (method == "PC1") {


### PR DESCRIPTION
## Summary
- allow NA values when inferring orientation
- relax checks for NA values when orienting data in `lpme`

## Testing
- `Rscript -e 'library(lpme); testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_685b15f4d358832fa7b51d13353b8c4e